### PR TITLE
修复在Java中当Compound作为List元素时的读取和写入bug

### DIFF
--- a/shen-nbt5/src/lib.rs
+++ b/shen-nbt5/src/lib.rs
@@ -63,10 +63,14 @@ pub mod nbt_version {
         fn write_i64_array(writer: &mut Vec<u8>, data: &[i64]);
         fn write_nbt_string(writer: &mut Vec<u8>, data: &str);
         fn write_list(writer: &mut Vec<u8>, data: &[NbtValue]) -> NbtResult<()>;
+        /// 向 `writer` 写入一个复合标签类型(Compound)
+        /// 
+        /// * `is_list_element` 用于指示是否为列表元素。当复合标签类型为列表元素时是不用将名称写入的。
         fn write_compound(
             writer: &mut Vec<u8>,
             name: Option<&String>,
             data: &[(String, NbtValue)],
+            is_list_element: bool,
         ) -> NbtResult<()>;
 
         fn write_to(value: &NbtValue, buff: &mut Vec<u8>) -> NbtResult<()>;

--- a/shen-nbt5/src/reader.rs
+++ b/shen-nbt5/src/reader.rs
@@ -57,7 +57,7 @@ impl nbt_version::NbtReadTrait for nbt_version::Java {
                 7 => NbtValue::ByteArray(Java::read_i8_array(reader)?),
                 8 => NbtValue::String(Java::read_nbt_string(reader)?),
                 9 => NbtValue::List(Java::read_list(reader)?),
-                10 => NbtValue::Compound(None, nbt_version::Java::read_compound(reader)?),
+                10 => NbtValue::Compound(Some(name.clone()), nbt_version::Java::read_compound(reader)?),
                 11 => NbtValue::IntArray(Java::read_i32_array(reader)?),
                 12 => NbtValue::LongArray(Java::read_i64_array(reader)?),
                 _ => return Err(NbtError::UnknownType(tag_id)),


### PR DESCRIPTION
当Compound作为List元素时，Compound是没有key的

我在使用该库解析Java版的MC原理图后，再将原理图保存后再解析时就会出现问题，经过解析发现当Compound作为List元素时，Compound是没有key的。

所以我修改了一些代码，将这一特殊情况修复了一下。但是我只修了Java的，其他的我也不知道是什么情况就没动。

测试和验证的MC版本：Java 1.20.4